### PR TITLE
Add framework dependencies to Podspec

### DIFF
--- a/PKAnimations.podspec
+++ b/PKAnimations.podspec
@@ -11,6 +11,5 @@ Pod::Spec.new do |s|
   s.source_files = 'PKAnimations/**/*.{h,m}'
   s.requires_arc = true
   s.dependency 'MGCommand', '0.1.1'
-
   s.ios.frameworks = 'Foundation', 'QuartzCore', 'CoreGraphics', 'UIKit'
 end

--- a/PKAnimations.podspec
+++ b/PKAnimations.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'MGCommand', '0.1.1'
 
-  s.ios.frameworks = 'QuartzCore'
+  s.ios.frameworks = 'Foundation', 'QuartzCore', 'CoreGraphics', 'UIKit'
 end

--- a/PKAnimations.podspec
+++ b/PKAnimations.podspec
@@ -11,4 +11,6 @@ Pod::Spec.new do |s|
   s.source_files = 'PKAnimations/**/*.{h,m}'
   s.requires_arc = true
   s.dependency 'MGCommand', '0.1.1'
+
+  s.ios.frameworks = 'QuartzCore'
 end


### PR DESCRIPTION
A link failure happens if we install the pod in a new project due to missing QuartzCore lib.
This config in the Podspec add all the framework necessary to build the pod.
