### PR TITLE
Compile error because QuartzCore headers are missing

### DIFF
--- a/PKAnimations.podspec
+++ b/PKAnimations.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'MGCommand'
   s.ios.frameworks = 'Foundation', 'QuartzCore', 'CoreGraphics', 'UIKit'
+  s.prefix_header_contents = "#import <QuartzCore/QuartzCore.h>"
 end


### PR DESCRIPTION
Using PKAnimations with CocoaPods running OS X 10.9 and Xcode 4.6.3 fails to compile. 
The problem is that QuartzCore headers are not explicitly imported in every file that uses CAAnimation and other QuartzCore classes. The fix is simply to update Podspec to produce a .pch file that includes QuartzCore headers.
